### PR TITLE
use parameter region when calling aws-cli

### DIFF
--- a/check_elb_instances.sh
+++ b/check_elb_instances.sh
@@ -45,7 +45,7 @@ if [[ -z ${LB_NAME} ]]; then
 fi
 
 
-CMD="/usr/bin/aws elb describe-instance-health"
+CMD="/usr/bin/aws $CMDOPT elb describe-instance-health"
 OPT="$OPT --load-balancer-name ${LB_NAME}"
 
 JSON=$(${CMD} ${OPT})


### PR DESCRIPTION
After longer timer not understanding why my argument got ignored, found a bug. 
Whit this PR the aws-cli will know the region and not check the configuration. 
